### PR TITLE
dtype issue fix for insertion and additional checks

### DIFF
--- a/tests/test_image_interpolation_2d.py
+++ b/tests/test_image_interpolation_2d.py
@@ -161,8 +161,8 @@ def test_insert_into_image_nearest_interp_2d():
     [torch.float32, torch.float64, torch.complex64, torch.complex128]
 )
 def test_insert_into_image_2d_type_consistency(dtype):
-    image = torch.rand((28, 28), dtype=dtype)
-    coords = torch.tensor(np.random.uniform(low=0, high=27, size=(3, 4, 2)))
+    image = torch.rand((4, 4), dtype=dtype)
+    coords = torch.tensor(np.random.uniform(low=0, high=3, size=(3, 4, 2)))
     values = torch.rand(size=(3, 4), dtype=dtype)
     # cast the dtype to corresponding float for weights
     weights = torch.zeros_like(image, dtype=torch.float64)
@@ -180,8 +180,8 @@ def test_insert_into_image_2d_type_consistency(dtype):
 
 
 def test_insert_into_image_3d_type_error():
-    image = torch.rand((28, 28), dtype=torch.complex64)
-    coords = torch.tensor(np.random.uniform(low=0, high=27, size=(3, 4, 2)))
+    image = torch.rand((4, 4), dtype=torch.complex64)
+    coords = torch.tensor(np.random.uniform(low=0, high=3, size=(3, 4, 2)))
     values = torch.rand(size=(3, 4), dtype=torch.complex128)
     # cast the dtype to corresponding float for weights
     with pytest.raises(ValueError):

--- a/tests/test_image_interpolation_3d.py
+++ b/tests/test_image_interpolation_3d.py
@@ -162,8 +162,8 @@ def test_insert_multiple_values_into_multichannel_image_2d_nearest():
     [torch.float32, torch.float64, torch.complex64, torch.complex128]
 )
 def test_insert_into_image_2d_type_consistency(dtype):
-    image = torch.rand((28, 28, 28), dtype=dtype)
-    coords = torch.tensor(np.random.uniform(low=0, high=27, size=(3, 4, 5, 3)))
+    image = torch.rand((4, 4, 4), dtype=dtype)
+    coords = torch.tensor(np.random.uniform(low=0, high=3, size=(3, 4, 5, 3)))
     values = torch.rand(size=(3, 4, 5), dtype=dtype)
     # cast the dtype to corresponding float for weights
     weights = torch.zeros_like(image, dtype=torch.float64)
@@ -181,8 +181,8 @@ def test_insert_into_image_2d_type_consistency(dtype):
 
 
 def test_insert_into_image_3d_type_error():
-    image = torch.rand((28, 28, 28), dtype=torch.complex64)
-    coords = torch.tensor(np.random.uniform(low=0, high=27, size=(3, 4, 5, 3)))
+    image = torch.rand((4, 4, 4), dtype=torch.complex64)
+    coords = torch.tensor(np.random.uniform(low=0, high=3, size=(3, 4, 5, 3)))
     values = torch.rand(size=(3, 4, 5), dtype=torch.complex128)
     # cast the dtype to corresponding float for weights
     with pytest.raises(ValueError):

--- a/tests/test_image_interpolation_3d.py
+++ b/tests/test_image_interpolation_3d.py
@@ -1,6 +1,7 @@
 import numpy as np
 import torch
 import einops
+import pytest
 
 from torch_image_interpolation import sample_image_3d, insert_into_image_3d
 
@@ -154,3 +155,39 @@ def test_insert_multiple_values_into_multichannel_image_2d_nearest():
     # check output shapes
     assert image.shape == (n_channels, 28, 28, 28)
     assert weights.shape == (28, 28, 28)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.float64, torch.complex64, torch.complex128]
+)
+def test_insert_into_image_2d_type_consistency(dtype):
+    image = torch.rand((28, 28, 28), dtype=dtype)
+    coords = torch.tensor(np.random.uniform(low=0, high=27, size=(3, 4, 5, 3)))
+    values = torch.rand(size=(3, 4, 5), dtype=dtype)
+    # cast the dtype to corresponding float for weights
+    weights = torch.zeros_like(image, dtype=torch.float64)
+
+    for mode in ['bilinear', 'nearest']:
+        image, weights = insert_into_image_3d(
+            values,
+            image=image,
+            weights=weights,
+            coordinates=coords,
+            interpolation=mode,
+        )
+        assert image.dtype == dtype
+        assert weights.dtype == torch.float64
+
+
+def test_insert_into_image_3d_type_error():
+    image = torch.rand((28, 28, 28), dtype=torch.complex64)
+    coords = torch.tensor(np.random.uniform(low=0, high=27, size=(3, 4, 5, 3)))
+    values = torch.rand(size=(3, 4, 5), dtype=torch.complex128)
+    # cast the dtype to corresponding float for weights
+    with pytest.raises(ValueError):
+        insert_into_image_3d(
+            values,
+            image=image,
+            coordinates=coords,
+        )


### PR DESCRIPTION
list of changes:
* added a valuerror check in case values and image for insertion do not have the same dtype
* added explicit dtype for weights allocation in linear insertion
* convert weight to data dtype in insertion to prevent upcasting but allow flexible weights -- this allows running with a weight tensor of float64 while the data dtype is complex64, makes input to the function the least error prone I think
* added tests to check for dtype and ensure valueerror is raised
  